### PR TITLE
Add Renegade to Gluing Queue

### DIFF
--- a/data/gluing_queue.json
+++ b/data/gluing_queue.json
@@ -129,6 +129,14 @@
       "trade_volume_7d_million": 0.00177,
       "tvl_million": 0.78302,
       "bounty": "None"
+    },
+    {
+      "protocol": "Renegade",
+      "docs": "https://docs.renegade.fi",
+      "chains": ["arbitrum"],
+      "trade_volume_7d_million": 0.126,
+      "tvl_million": 0.15,
+      "bounty": "None"
     }
   ]
 }


### PR DESCRIPTION
Adds Renegade (https://twitter.com/renegade_fi) to the queue!

Data source: https://trade.renegade.fi

SDK docs:
https://github.com/renegade-fi/rust-sdk
https://github.com/renegade-fi/golang-sdk
https://github.com/renegade-fi/python-sdk
https://github.com/renegade-fi/typescript-sdk