### PR TITLE
Balancer v3 Weighted Pools with Akron Hooks: add to queue

### DIFF
--- a/data/gluing_queue.json
+++ b/data/gluing_queue.json
@@ -3798,6 +3798,30 @@
       "prs":[
           
       ]
-    }
+    },    
+    {
+      "protocol":"Balancer v3 Weighted Pools with Akron Hooks",
+      "docs":"https://crocus-sidewalk-9c5.notion.site/Balancer-Weighted-Pool-implementing-Akron-LVR-linked-Dynamic-Swap-Fee-Hook-1697cd41d8b880e1840be00404df2e3a?pvs=4",
+      "chains":[
+        "arbitrum",
+        "base"
+      ],
+      "trade_volume_7d_million":null,
+      "tvl_million":0.01,
+      "bounty_add_on":{
+        "amount":null,
+        "decimals":null,
+        "token_address":null,
+        "token_symbol":null,
+        "network":null
+      },
+      "status":"not_glued",
+      "active_gluers":[
+        
+      ],
+      "prs":[
+        
+      ]
+  }
   ]
 }


### PR DESCRIPTION
# Gluing Queue Update Request Template

## Protocol Information (If PR type is "add to queue")
- **Protocol Name:** Balancer v3 Weighted Pools with Akron Hooks
- **Docs:** https://crocus-sidewalk-9c5.notion.site/Balancer-Weighted-Pool-implementing-Akron-LVR-linked-Dynamic-Swap-Fee-Hook-1697cd41d8b880e1840be00404df2e3a 
- **Deployed Chains:** [Base, Arbitrum] 
- **Trade Volume (7D) in million USD:** 0.01
- **Total Value Locked (TVL) in million USD:** 0.01
- **Is Fork**: True
- **Forked From**: Balancer v3 Weighted Pool (the only difference is the dynamic swap fee percentage from the Akron hook)

## References & Verification (If PR type is "add to queue")
- **Trade Volume Source:** https://balancer.fi/pools?textSearch=akron
- **TVL Source:** https://balancer.fi/pools?textSearch=akron
- **Other Relevant Proofs:** https://balancer.fi/pools?textSearch=akron

## Bounty (Optional)
- Are you offering a reward for faster integration? **[Yes/No]**  
- If yes, specify the amount: **[XX GLX tokens or equivalent]**  

## Reason for Update (Optional)
Assuming GlueX has already integrated Balancer v3 standard Weighted Pools from the standard WeightedPoolFactory, the only change to the standard Weighted Pool is the change from standard static fees to Akron dynamic fees (Balancer v3 Weighted Pools with Akron Hooks are created from the standard WeightedPoolFactory).

## Contact
- Telegram: limete13   (there is an existing group with Felix and Frederico)
- X: https://x.com/AkronFinance/




