### PR TITLE
Remove latch from the gluing queue

### DIFF
--- a/data/gluing_queue.json
+++ b/data/gluing_queue.json
@@ -3253,29 +3253,6 @@
         ]
     },
     {
-        "protocol":"Latch",
-        "docs":null,
-        "chains":[
-          "ethereum"
-        ],
-        "trade_volume_7d_million":null,
-        "tvl_million":14.24,
-        "bounty_add_on":{
-          "amount":null,
-          "decimals":null,
-          "token_address":null,
-          "token_symbol":null,
-          "network":null
-        },
-        "status":"not_glued",
-        "active_gluers":[
-          
-        ],
-        "prs":[
-          
-        ]
-    },
-    {
         "protocol":"CLever",
         "docs":null,
         "chains":[


### PR DESCRIPTION
Latch has cross-chain staking, staking tokens are given to the users on the Gravity chain. Protocol cannot be integrated.

![image](https://github.com/user-attachments/assets/bd62eef7-3681-4325-9fce-700f65bb3b38)
![image](https://github.com/user-attachments/assets/495d811a-d3d6-4f42-a56a-2a12d1c2a239)
