### PR TITLE
Clipper, Lagoon: remove from queue | SwapX V2, Pharaoh, Shadow Exchange, Velodrome, Fluid, Equalizer, Aerodrome: update status

### DIFF
--- a/data/gluing_queue.json
+++ b/data/gluing_queue.json
@@ -42,7 +42,7 @@
           "token_symbol":null,
           "network":null
         },
-        "status":"glue_pending",
+        "status":"glued",
         "active_gluers":[
            "https://github.com/daksha-gluex"
         ],
@@ -208,7 +208,7 @@
           "token_symbol":null,
           "network":null
         },
-        "status":"glue_pending",
+        "status":"glued",
         "active_gluers":[
           "https://github.com/daksha-gluex"
         ],
@@ -231,7 +231,7 @@
           "token_symbol":null,
           "network":null
         },
-        "status":"glue_pending",
+        "status":"glued",
         "active_gluers":[
           "https://github.com/daksha-gluex"
         ],
@@ -277,7 +277,7 @@
           "token_symbol":null,
           "network":null
         },
-        "status":"glue_pending",
+        "status":"glued",
         "active_gluers":[
           "https://github.com/daksha-gluex"
         ],
@@ -582,7 +582,7 @@
           "token_symbol":null,
           "network":null
         },
-        "status":"being_glued",
+        "status":"glued",
         "active_gluers":[
           "https://github.com/daksha-gluex"
         ],
@@ -1761,7 +1761,7 @@
           "token_symbol":null,
           "network":null
         },
-        "status":"glue_pending",
+        "status":"glued",
         "active_gluers":[
           "https://github.com/daksha-gluex"
         ],
@@ -1784,7 +1784,7 @@
           "token_symbol":null,
           "network":null
       },
-      "status":"glue_pending",
+      "status":"glued",
       "active_gluers":[
           "https://github.com/daksha-gluex"
       ],
@@ -3104,34 +3104,6 @@
         ]
     },
     {
-        "protocol":"Clipper",
-        "docs":null,
-        "chains":[
-          "ethereum",
-          "polygon",
-          "optimism",
-          "arbitrum",
-          "base",
-          "mantle"
-        ],
-        "trade_volume_7d_million":4.31,
-        "tvl_million":4.04,
-        "bounty_add_on":{
-          "amount":null,
-          "decimals":null,
-          "token_address":null,
-          "token_symbol":null,
-          "network":null
-        },
-        "status":"not_glued",
-        "active_gluers":[
-          
-        ],
-        "prs":[
-          
-        ]
-    },
-    {
         "protocol":"Gearbox",
         "docs":null,
         "chains":[
@@ -3504,29 +3476,6 @@
         ]
     },
     {
-        "protocol":"Lagoon",
-        "docs":null,
-        "chains":[
-          "ethereum"
-        ],
-        "trade_volume_7d_million":null,
-        "tvl_million":36.56,
-        "bounty_add_on":{
-          "amount":null,
-          "decimals":null,
-          "token_address":null,
-          "token_symbol":null,
-          "network":null
-        },
-        "status":"not_glued",
-        "active_gluers":[
-          
-        ],
-        "prs":[
-          
-        ]
-    },
-    {
         "protocol":"stHype",
         "docs":"https://purrsec.com/address/0xffaa4a3d97fe9107cef8a3f48c069f577ff76cc1/contract",
         "chains":[
@@ -3668,38 +3617,6 @@
           "submitted_at":"2025-05-19T11:13:00Z"
         }
       ]
-    },
-    {
-        "protocol":"Lagoon",
-        "docs": "https://docs.lagoon.finance/",
-        "chains":[
-          "ethereum",
-          "arbitrum",
-          "base",
-          "unichain",
-          "berachain",
-          "sonic"
-        ],
-        "trade_volume_7d_million":null,
-        "tvl_million":36.56,
-        "bounty_add_on":{
-          "amount":null,
-          "decimals":null,
-          "token_address":null,
-          "token_symbol":null,
-          "network":null
-        },
-        "status":"being_glued",
-        "active_gluers":[
-          "https://github.com/hanzceo"
-        ],
-        "prs":[
-          {
-              "author":"https://github.com/hanzceo",
-              "url":"https://github.com/gluexprotocol/liquidity-module-self-integration/pull/14",
-              "submitted_at":"2025-05-19T11:13:00Z"
-          }
-        ]
     },
     {
         "protocol":"CLever",


### PR DESCRIPTION
In Lagoon Protocol, both the deposit and redeem processes are multi-step. Link to their docs explaining the processes - https://docs.lagoon.finance/vault/deposit-and-withdraw-flows

In Clipper they have both on-chain and off-chain computations. Their off chain calculations are not public and the swap function needs a designated signer so we cannot integrate this either.

I've also updated the statuses of other modules that have been glued.