### PR TITLE
VaultCraft: `not_glued` to `being_glued`

### DIFF
--- a/data/gluing_queue.json
+++ b/data/gluing_queue.json
@@ -3715,9 +3715,9 @@
           "token_symbol":null,
           "network":null
         },
-        "status":"not_glued",
+        "status":"being_glued",
         "active_gluers":[
-          
+          "https://github.com/eshumanohare"
         ],
         "prs":[
           


### PR DESCRIPTION
## Protocol Information (If PR type is "add to queue")
- **Protocol Name:** VaultCraft
- **Docs:** https://docs.vaultcraft.io/
- **Deployed Chains:** [ethereum, arbitrum, optimism, polygon, base, bsc]  
- **Trade Volume (7D) in million USD:**
- **Total Value Locked (TVL) in million USD:** 108.82  
- **Is Fork**: False
- **Forked From**:

## References & Verification (If PR type is "add to queue")
- **Trade Volume Source:** 
- **TVL Source:** https://defillama.com/protocol/tvl/vaultcraft 